### PR TITLE
andSelf is deprecated and removed in 3.0; change to .addBack

### DIFF
--- a/jquery.evenifhidden.js
+++ b/jquery.evenifhidden.js
@@ -14,7 +14,7 @@
             var _this = $(this);
             var currentStyles = [];
 
-            var hiddenElements = _this.parents().andSelf().filter(':hidden');
+            var hiddenElements = _this.parents().addBack().filter(':hidden');
 
             if (!hiddenElements.length) {
                 callback(_this);


### PR DESCRIPTION
[per jQuery documentation](https://api.jquery.com/andself/), .addBack performs identically to .addSelf